### PR TITLE
Add themed 404 page

### DIFF
--- a/sass/assets/css/style.scss
+++ b/sass/assets/css/style.scss
@@ -104,6 +104,22 @@ pre,code {
   background-color: initial;
 }
 
+.not-found-page {
+  display: flex;
+  align-items: center;
+  min-height: 60vh;
+}
+
+.not-found-page .post {
+  width: 100%;
+}
+
+.not-found-code {
+  font-size: 50px;
+  line-height: 1;
+  margin-bottom: 0.75rem;
+}
+
 .eiptable .title {
   width: 67%;
 }

--- a/templates/404.html
+++ b/templates/404.html
@@ -1,0 +1,39 @@
+{% extends "base.html" %}
+
+{% block title -%}
+404 Not Found | {{ config.title -}}
+{% endblock title %}
+
+{% block extra_head %}
+<meta property="og:title" content="404 Not Found | {{ config.title }}" />
+<meta property="og:type" content="website" />
+<script type="application/ld+json">
+	{
+		"@type": "WebPage",
+		"url": "{{ get_url(path='/404.html', trailing_slash=false) | safe }}",
+		"name": "404 Not Found | {{ config.title }}",
+		"description": "{{ config.description }}",
+		"@context": "https://schema.org"
+	}
+</script>
+{% endblock extra_head %}
+
+{% block content %}
+<section class="not-found-page" aria-labelledby="not-found-title">
+	<article class="post">
+		<header class="post-header">
+			<p class="post-meta not-found-code">404</p>
+			<h1 class="post-title" id="not-found-title">Page not found</h1>
+		</header>
+		<div class="post-content">
+			<p>The page you requested does not exist or may have moved.</p>
+			<p>You can return to the homepage, browse proposal lists, or use search to find the document you need.</p>
+			<p>
+				<a href="{{ get_url(path='/', trailing_slash=false) }}">Return home</a>
+				<span aria-hidden="true"> · </span>
+				<a href="{{ get_url(path='/status/', trailing_slash=false) }}">Browse proposals</a>
+			</p>
+		</div>
+	</article>
+</section>
+{% endblock content %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -16,7 +16,9 @@
 		<link rel="apple-touch-icon" href="/assets/images/apple-touch-icon.png" />
 
 		<meta property="og:site_name" content="{{ config.title }}" />
+		{% if current_url %}
 		<link property="og:url" href="{{ current_url }}" />
+		{% endif %}
 
 		{% block extra_head %}
 		<meta property="og:title" content="{{ config.title }}" />


### PR DESCRIPTION
## Description

Adds an EIP themed 404 page.

**Mobile**
<img width="400" height="720" alt="404-mobile" src="https://github.com/user-attachments/assets/0ea61e5e-ad5f-4cdb-9f56-42bfd3a86217" />

<br /> <br />

**Desktop**
<img width="1920" height="945" alt="404-desktop" src="https://github.com/user-attachments/assets/8a69ae57-2210-40eb-b8e5-e8598be09b14" />

