### PR TITLE
Improve EIP badge UI clarity

### DIFF
--- a/sass/assets/css/style.scss
+++ b/sass/assets/css/style.scss
@@ -77,6 +77,7 @@ a:hover, a:active {
 }
 
 .badge:hover {
+  cursor: pointer;
   filter: brightness(75%);
   transition: all 0.25s ease;
 }
@@ -178,13 +179,20 @@ pre,code {
   content: '🚧 ';
 }
 
-.tax-term-draft, .tax-term-review {
+.badge.text-light.tax-term-draft,
+.badge.text-light.tax-term-review {
   --bs-bg-opacity: 1;
   background-color: rgba(var(--bs-warning-rgb),var(--bs-bg-opacity)) !important;
+  color: #000 !important;
 }
 
 .tax-term-draft::before, .tax-term-review::before {
   content: '⚠️ ';
+}
+
+.tax-term-living {
+  --bs-bg-opacity: 1;
+  background-color: rgba(var(--bs-primary-rgb),var(--bs-bg-opacity)) !important;
 }
 
 .giallo-l {


### PR DESCRIPTION
## Description

- Replace low-contrast white text with dark text on warning-colored Draft and Review badges for improved visibility.

- Give Living badges a distinct primary blue color so the special status stands out.

- Add a pointer cursor on badge hover to make tooltip-enabled badge interactions clearer.

**Demo site:** [wg-eips.ritovision.com](https://wg-eips.ritovision.com)

## Before and After

### Before
*Notice the cursor triggering the tooltip hover is a typing cursor despite being a pointer interaction; the yellow pills' white text are very difficult to read due to low contrast, the "Living" pill appears ordinary despite being a very unique status label*
<img width="1106" alt="badges-before" src="https://github.com/user-attachments/assets/9064ddf6-4be4-4b18-9184-477859206008" />

<br /><br />

### After
<img width="1106" alt="badges-after" src="https://github.com/user-attachments/assets/5fc4cb95-88d9-47d6-85d4-b9e696f139d8" />
