### PR TITLE
Fix table and text overflow

### DIFF
--- a/sass/assets/css/style.scss
+++ b/sass/assets/css/style.scss
@@ -53,6 +53,14 @@ header hgroup * {
   overflow-wrap: anywhere;
 }
 
+@include media-query($on-laptop) {
+  table {
+    display: inline-block;
+    max-width: 100%;
+    width: auto !important;
+  }
+}
+
 table.preamble > tbody > tr > :not(:first-child) {
   width: 100%;
 }
@@ -116,6 +124,7 @@ pre,code {
 }
 
 .eiptable .title {
+  min-width: 300px;
   width: 67%;
 }
 
@@ -126,6 +135,7 @@ pre,code {
 }
 
 .eiptable .author {
+  max-width: 300px;
   min-width: 33%;
 }
 

--- a/sass/assets/css/style.scss
+++ b/sass/assets/css/style.scss
@@ -42,6 +42,17 @@ $content-width: 1152px;
   background-color: rgba(0,0,0,0) !important;
 }
 
+header hgroup,
+header hgroup * {
+  overflow-wrap: anywhere;
+}
+
+.wrap-anywhere,
+.wrap-anywhere th,
+.wrap-anywhere td {
+  overflow-wrap: anywhere;
+}
+
 table.preamble > tbody > tr > :not(:first-child) {
   width: 100%;
 }

--- a/templates/eip.html
+++ b/templates/eip.html
@@ -200,7 +200,7 @@
 			</h1>
 			<p role="doc-subtitle">{{ page.description }}</p>
 		</hgroup>
-		<table class="table table-borderless preamble">
+		<table class="table table-borderless preamble wrap-anywhere">
 			<tbody>
 				<tr>
 					<th scope="row">Authors</th>


### PR DESCRIPTION
## Description

Improves table and header text layout on narrow viewports without removing the table overflow behavior needed for genuinely wide content.

- Keeps mobile tables sized to their content instead of forcing full-width layout with large empty space inside the table border.
- Caps inline-block tables to the available width so oversized tables can still fall back to horizontal scrolling.
- Adds wrapping for long EIP preamble metadata, including long author names and discussion links to prevent the container from having horizontal scroll overflow.
- Allows EIP header text to wrap before it creates horizontal scroll overflow.
- Gives proposal listing titles a stable minimum width to remain readable on small screens.
- Caps proposal listing author cells so one long author entry does not expand the whole table.

Closes #6
Closes #7

**Demo site:** [wg-eips.ritovision.com](https://wg-eips.ritovision.com/)

## Before and After Images

### Table border empty gaps
#### Before
<img src="https://github.com/user-attachments/assets/55181b1d-513a-4c08-a440-527686be2e83" alt="WG example" width="400">

#### After
<img width="400" alt="empty-table-fix" src="https://github.com/user-attachments/assets/0a629966-5794-4774-9ff5-cc2fe654a03f" />

### Header table overflow
#### Before
<img src="https://github.com/user-attachments/assets/579591d0-b878-4f61-ad4d-ca37a0c8f38c" alt="WG example - 495 screen size" width="400">

#### After
<img width="400" alt="header-text-overflow fix" src="https://github.com/user-attachments/assets/b91782ed-00bb-4b31-aef5-d13392deaa9a" />
